### PR TITLE
add setBucket method

### DIFF
--- a/src/AwsS3Adapter.php
+++ b/src/AwsS3Adapter.php
@@ -106,6 +106,16 @@ class AwsS3Adapter extends AbstractAdapter
     }
 
     /**
+     * Set the S3Client bucket. Used for overriding the default bucket.
+     *
+     * @param string $bucket
+     */
+    public function setBucket($bucket)
+    {
+        $this->bucket = $bucket;
+    }
+
+    /**
      * Get the S3Client instance.
      *
      * @return S3Client

--- a/tests/AwsS3AdapterTests.php
+++ b/tests/AwsS3AdapterTests.php
@@ -57,6 +57,16 @@ class AwsS3Tests extends PHPUnit_Framework_TestCase
         $this->assertEquals('bucket', $adapter->getBucket());
     }
 
+    public function testSetBucket()
+    {
+        $mock = $this->getS3Client();
+        $adapter = new Adapter($mock, 'bucket');
+        $this->assertEquals('bucket', $adapter->getBucket());
+
+        $adapter->setBucket('newBucket');
+        $this->assertEquals('newBucket', $adapter->getBucket());
+    }
+
     public function testGetClient()
     {
         $mock = $this->getS3Client();


### PR DESCRIPTION
I am using this adapter in a system that works with multiple S3 buckets. We have design constraints that make it difficult to instance a new one each time we switch buckets. This change lets us modify the bucket on the fly, using the same adapter.
